### PR TITLE
Support failure-0.2

### DIFF
--- a/Control/Monad/Exception.hs
+++ b/Control/Monad/Exception.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 
 {-|
 A Monad Transformer for explicitly typed checked exceptions, described in detail by:
@@ -74,8 +75,11 @@ module Control.Monad.Exception (
 
 -- * Reexports
     Exception(..), SomeException(..), Typeable(..),
+    Failure(..),
+#if !MIN_VERSION_failure(0,2,0)
     Try(..), NothingException(..),
-    Failure(..), WrapFailure(..),
+    WrapFailure(..),
+#endif
     MonadLoc(..), withLocTH
 ) where
 

--- a/Control/Monad/Exception/Base.hs
+++ b/Control/Monad/Exception/Base.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts, FlexibleInstances, TypeSynonymInstances #-}
@@ -111,6 +112,7 @@ instance Monad m => Applicative (EMT l m) where
 instance (Exception e, Throws e l, Monad m) => Failure e (EMT l m) where
   failure = throw
 
+#if !MIN_VERSION_failure(0,2,0)
 instance (Exception e, Throws e l, Failure e m, Monad m) => WrapFailure e (EMT l m) where
   wrapFailure mkE m
       = EMT $ do
@@ -119,6 +121,7 @@ instance (Exception e, Throws e l, Failure e m, Monad m) => WrapFailure e (EMT l
             Right _ -> return v
             Left (loc, CheckedException (SomeException e))
                     -> return $ Left (loc, CheckedException $ toException $ mkE e)
+#endif
 
 instance MonadTrans (EMT l) where
   lift = EMT . liftM Right

--- a/control-monad-exception.cabal
+++ b/control-monad-exception.cabal
@@ -79,7 +79,7 @@ Flag extensibleExceptions
 
 Library
   buildable: True 
-  build-depends: failure >= 0.1 && < 0.2
+  build-depends: failure >= 0.1 && < 0.3
                , transformers
                , monadloc
 


### PR DESCRIPTION
Hi Pepe,

I would like to try out `control-monad-exception` in a project of mine. However one of my dependencies depends on `failure >= 0.2` while `control-monad-exception` depends on `failure < 0.2`. Cabal complains about this.

The attached patch adds support for `failure-0.2` by only enabling the code for `failure < 0.2` if the package is configured for that version.

Regards,

Bas
