### PR TITLE
cabal: upgrading to 1.10 

### DIFF
--- a/control-monad-exception.cabal
+++ b/control-monad-exception.cabal
@@ -1,6 +1,6 @@
 name: control-monad-exception
 version: 0.10.1
-Cabal-Version:  >= 1.6
+Cabal-Version:  >= 1.10
 build-type: Simple
 license: PublicDomain
 author: Pepe Iborra
@@ -78,6 +78,7 @@ Flag extensibleExceptions
   default: False
 
 Library
+  default-language: Haskell98
   buildable: True 
   build-depends: failure >= 0.1 && < 0.3
                , transformers >= 0.2
@@ -91,14 +92,22 @@ Library
     build-depends:
       base >= 4 && < 5
 
-  extensions:  MultiParamTypeClasses,
-               ScopedTypeVariables,
-               FlexibleContexts,
-               FlexibleInstances,
-               TypeSynonymInstances,
-               EmptyDataDecls,
-               DeriveDataTypeable,
-               PatternGuards
+  default-extensions:
+     CPP
+     DeriveDataTypeable
+     EmptyDataDecls
+     ExistentialQuantification
+     FlexibleContexts
+     FlexibleInstances
+     FunctionalDependencies
+     MultiParamTypeClasses
+     OverlappingInstances
+     PackageImports
+     PatternGuards
+     ScopedTypeVariables
+     TypeFamilies
+     TypeSynonymInstances
+     UndecidableInstances
 
   exposed-modules:
      Control.Monad.Exception


### PR DESCRIPTION
when building control-monad-exception-0.10.1 via cabal I got this error:

> [3 of 4] Compiling Control.Monad.Exception.Base (
> Control/Monad/Exception/Base.hs, dist/build/Control/Monad/Exception/Base.o )
> 
> Control/Monad/Exception/Base.hs:117:60:
>     Not in scope: type constructor or class `WrapFailure'
> 
> Control/Monad/Exception/Base.hs:118:2:
>     `wrapFailure' is not a (visible) method of class`WrapFailure'

using failure-0.1.0.1 instead of failure-0.2.0.1 fixed the issue. But I wasn't
satisfied with this solution, so I investigated a bit more time.

I encountered this problem on a system A, but I hadn't it on a different system B.

System A:

> $ ghc --version
> The Glorious Glasgow Haskell Compilation System, version 6.12.1
> $ cabal --version
> cabal-install version 0.8.0
> using version 1.8.0.2 of the Cabal library

System B:

> $ ghc --version
> The Glorious Glasgow Haskell Compilation System, version 7.4.1
> $ cabal --version
> cabal-install version 0.10.4
> using version 1.14.0 of the Cabal library

so, upgrading cabal via

> $ cabal install cabal-install
> $ export PATH=~/.cabal/bin:$PATH

did the trick on system A. I guess the old version of cabal didn't support the
MIN_VERSION macro (at least in that way it's used here).

therefore, let's specify that requirement in the cabal file. I also added all
extensions used to the cabal file while I'm on it anyways.

Thanks,
Bernhard
